### PR TITLE
Expose ResizeObserverEntry type

### DIFF
--- a/src/Web/ResizeObserver.purs
+++ b/src/Web/ResizeObserver.purs
@@ -1,6 +1,9 @@
 module Web.ResizeObserver
   ( ResizeObserver
   , ResizeObserverBoxOptions(..)
+  , ResizeObserverEntry
+  , ResizeObserverEntry'
+  , ResizeObserverSize
   , resizeObserver
   , observe
   , unobserve


### PR DESCRIPTION
Hi @nsaunders

Thanks a lot for building the lib!

I'm exposing `ResizeObserverEntry` type in this trivial PR. Could you please tell me if you are hiding these types on purpose? 